### PR TITLE
feat(sd): 목업 데이터 및 유효 id 범위 확장, 페이지네이션 로직 개선 (#27)

### DIFF
--- a/src/test/java/org/ever/_4ever_be_gw/domain/mm/MmPurchaseTest.java
+++ b/src/test/java/org/ever/_4ever_be_gw/domain/mm/MmPurchaseTest.java
@@ -139,9 +139,14 @@ class MmPurchaseTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.message").value("발주서 목록 조회에 성공했습니다."))
-                .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data[0].id").value(1001))
-                .andExpect(jsonPath("$.data[0].status").value("APPROVED"));
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.content[0].id").value(1001))
+                .andExpect(jsonPath("$.data.content[0].status").value("APPROVED"))
+                .andExpect(jsonPath("$.data.page.number").value(0))
+                .andExpect(jsonPath("$.data.page.size").value(10))
+                .andExpect(jsonPath("$.data.page.totalElements").exists())
+                .andExpect(jsonPath("$.data.page.totalPages").exists())
+                .andExpect(jsonPath("$.data.page.hasNext").exists());
     }
 
     @Test
@@ -188,16 +193,16 @@ class MmPurchaseTest {
     }
 
     @Test
-    @DisplayName("발주서 상세 조회 성공(1~10)")
+    @DisplayName("발주서 상세 조회 성공(1001~1050)")
     void getPurchaseOrderDetail_success() throws Exception {
-        mockMvc.perform(get("/api/scm-pp/mm/purchase-orders/{purchaseId}", 1L)
+        mockMvc.perform(get("/api/scm-pp/mm/purchase-orders/{purchaseId}", 1001L)
                         .servletPath("/api")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.message").value("발주서 상세 정보 조회에 성공했습니다."))
-                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.id").value(1001))
                 .andExpect(jsonPath("$.data.poNumber").exists())
                 .andExpect(jsonPath("$.data.items").isArray());
     }
@@ -205,13 +210,13 @@ class MmPurchaseTest {
     @Test
     @DisplayName("발주서 상세 미존재 404(범위 밖)")
     void getPurchaseOrderDetail_notFound() throws Exception {
-        mockMvc.perform(get("/api/scm-pp/mm/purchase-orders/{purchaseId}", 11L)
+        mockMvc.perform(get("/api/scm-pp/mm/purchase-orders/{purchaseId}", 1051L)
                         .servletPath("/api")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.message").value("해당 발주서를 찾을 수 없습니다: poId=11"));
+                .andExpect(jsonPath("$.message").value("해당 발주서를 찾을 수 없습니다: poId=1051"));
     }
     @Test
     @DisplayName("구매요청 상세 조회 성공(1~10)")
@@ -244,12 +249,12 @@ class MmPurchaseTest {
     @Test
     @DisplayName("구매요청 상세 미존재 404(범위 밖)")
     void getPurchaseRequisitionDetail_notFound() throws Exception {
-        mockMvc.perform(get("/api/scm-pp/mm/purchase-requisitions/{purchaseId}", 11L)
+        mockMvc.perform(get("/api/scm-pp/mm/purchase-requisitions/{purchaseId}", 51L)
                         .servletPath("/api")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.message").value("해당 구매요청서를 찾을 수 없습니다: purchaseId=11"));
+                .andExpect(jsonPath("$.message").value("해당 구매요청서를 찾을 수 없습니다: purchaseId=51"));
     }
 }

--- a/src/test/java/org/ever/_4ever_be_gw/domain/mm/MmVendorTest.java
+++ b/src/test/java/org/ever/_4ever_be_gw/domain/mm/MmVendorTest.java
@@ -64,8 +64,8 @@ class MmVendorTest {
                 .andExpect(jsonPath("$.data.content[0].vendorCode").value("SUP001"))
                 .andExpect(jsonPath("$.data.page.number").value(0))
                 .andExpect(jsonPath("$.data.page.size").value(10))
-                .andExpect(jsonPath("$.data.page.totalElements").value(5))
-                .andExpect(jsonPath("$.data.page.hasNext").value(false));
+                .andExpect(jsonPath("$.data.page.totalElements").value(50))
+                .andExpect(jsonPath("$.data.page.hasNext").value(true));
     }
 
     @Test
@@ -131,7 +131,7 @@ class MmVendorTest {
     @Test
     @DisplayName("공급업체 상세 미존재 404")
     void getVendorDetail_notFound() throws Exception {
-        mockMvc.perform(get("/api/scm-pp/mm/vendors/{vendorId}", 11L)
+        mockMvc.perform(get("/api/scm-pp/mm/vendors/{vendorId}", 51L)
                         .servletPath("/api")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())


### PR DESCRIPTION
## 요약
- 구매요청서 및 발주서 목업 데이터: 10건 → 50건
- 유효 ID 범위 확장:
  - 구매요청서: 1~10 → 1~50
  - 발주서: 1001~1010 → 1001~1050
  - 공급사 목록: 1~10 → 1~50
- 동적 데이터 생성 로직 개선:
  - ID, 날짜, 금액 계산 방식 리팩토링
  - 페이지네이션 메타데이터 처리 로직 변경
- 테스트 케이스와 Swagger 예제 데이터 업데이트

## 관련 이슈
- Closes #27 