### PR TITLE
fix(security): cors 허용 도메인 및 options 메서드 허용 추가 (#135)

### DIFF
--- a/src/main/java/org/ever/_4ever_be_gw/config/security/SecurityConfig.java
+++ b/src/main/java/org/ever/_4ever_be_gw/config/security/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2Res
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -45,6 +46,7 @@ public class SecurityConfig {
             .sessionManagement(
                 session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers("/actuator/**").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 .requestMatchers("/api/**").authenticated()
@@ -62,14 +64,12 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOriginPatterns(List.of(
             "https://api.everp.co.kr",
+            "https://everp.co.kr",
+            "https://4-ever-fe.vercel.app",
             "http://localhost:8080",
             "http://127.0.0.1:8080",
             "http://localhost:3000",
-            "http://127.0.0.1:3000",
-            "https://4-ever-fe.vercel.app/**",
-            "https://4-ever-fe.vercel.app/",
-            "https://everp.co.kr/**",
-            "https://everp.co.kr/"
+            "http://127.0.0.1:3000"
         ));
         config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
## 요약
- CORS 허용 도메인에 `https://everp.co.kr`, `https://4-ever-fe.vercel.app` 추가
- 모든 경로에 대해 OPTIONS 메서드 허용 처리 추가 (`requestMatchers` 수정)

## 관련 이슈
- Closes #135 